### PR TITLE
Use molecule.conformers[0] directly

### DIFF
--- a/ibstore/_store.py
+++ b/ibstore/_store.py
@@ -294,6 +294,7 @@ class MoleculeStore:
                     ),
                     mapped_smiles=molecule_record.mapped_smiles,
                     qc_record=qcarchive_record,
+                    coordinates=molecule.conformers[0],
                 ),
             )
 

--- a/ibstore/_tests/unit_tests/test_models.py
+++ b/ibstore/_tests/unit_tests/test_models.py
@@ -18,6 +18,7 @@ def test_load_from_qcsubmit(small_collection):
             molecule_id="1",
             mapped_smiles=mapped_smiles,
             qc_record=qc_record,
+            coordinates=molecule.conformers[0],
         )
 
         assert isinstance(molecule_record, MoleculeRecord)

--- a/ibstore/_tests/unit_tests/test_store.py
+++ b/ibstore/_tests/unit_tests/test_store.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 import pytest
@@ -9,8 +10,7 @@ from ibstore.exceptions import DatabaseExistsError
 
 def test_from_qcsubmit(small_collection):
     store = MoleculeStore.from_qcsubmit_collection(
-        small_collection,
-        "foo.sqlite",
+        small_collection, "foo.sqlite"
     )
 
     # Sanity check molecule deduplication
@@ -18,6 +18,8 @@ def test_from_qcsubmit(small_collection):
 
     # Ensure a new object can be created from the same database
     assert len(MoleculeStore("foo.sqlite")) == len(store)
+
+    os.remove("foo.sqlite")
 
 
 def test_do_not_overwrite(small_collection):

--- a/ibstore/_tests/unit_tests/test_store.py
+++ b/ibstore/_tests/unit_tests/test_store.py
@@ -1,25 +1,22 @@
-import os
 import tempfile
 
 import pytest
-from openff.utilities import get_data_file_path
+from openff.utilities import get_data_file_path, temporary_cd
 
 from ibstore._store import MoleculeStore
 from ibstore.exceptions import DatabaseExistsError
 
 
 def test_from_qcsubmit(small_collection):
-    store = MoleculeStore.from_qcsubmit_collection(
-        small_collection, "foo.sqlite"
-    )
+    db = "foo.sqlite"
+    with temporary_cd():
+        store = MoleculeStore.from_qcsubmit_collection(small_collection, db)
 
-    # Sanity check molecule deduplication
-    assert len(store.get_smiles()) == len({*store.get_smiles()})
+        # Sanity check molecule deduplication
+        assert len(store.get_smiles()) == len({*store.get_smiles()})
 
-    # Ensure a new object can be created from the same database
-    assert len(MoleculeStore("foo.sqlite")) == len(store)
-
-    os.remove("foo.sqlite")
+        # Ensure a new object can be created from the same database
+        assert len(MoleculeStore(db)) == len(store)
 
 
 def test_do_not_overwrite(small_collection):

--- a/ibstore/models.py
+++ b/ibstore/models.py
@@ -51,12 +51,13 @@ class QMConformerRecord(Record):
         molecule_id: int,
         mapped_smiles: str,
         qc_record: OptimizationRecord,
+        coordinates,
     ):
         return cls(
             molecule_id=molecule_id,
             qcarchive_id=qc_record.id,
             mapped_smiles=mapped_smiles,
-            coordinates=qc_record.get_final_molecule().geometry * bohr2angstroms,
+            coordinates=coordinates,
             energy=qc_record.get_final_energy() * hartree2kcalmol,
         )
 


### PR DESCRIPTION
Hey Matt, I was doing some profiling on the code I mentioned in the meeting and on slack, and I saw that a ton of the time was being spent in the call to `get_final_molecule`, which appears to make a request to qcarchive for every single geometry:

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   2301/1    0.038    0.000  112.856  112.856 {built-in method builtins.exec}
        1    0.000    0.000  112.856  112.856 main.py:1(<module>)
        1    0.000    0.000  110.461  110.461 core.py:1155(__call__)
        1    0.000    0.000  110.461  110.461 core.py:1010(main)
        1    0.000    0.000  110.461  110.461 core.py:1423(invoke)
        1    0.000    0.000  110.461  110.461 core.py:732(invoke)
        1    0.002    0.002  110.461  110.461 main.py:17(main)
        1    0.013    0.013  102.361  102.361 _store.py:267(from_qcsubmit_collection)
      403    0.039    0.000   87.409    0.217 client.py:240(_automodel_request)
      403    0.004    0.000   86.911    0.216 client.py:203(_request)
      403    0.006    0.000   86.907    0.216 api.py:62(get)
      403    0.006    0.000   86.901    0.216 api.py:14(request)
      403    0.006    0.000   86.838    0.215 sessions.py:502(request)
      401    0.012    0.000   86.538    0.216 client.py:372(query_molecules)
      403    0.012    0.000   86.307    0.214 sessions.py:673(send)
      400    0.018    0.000   85.300    0.213 models.py:48(from_qcarchive_record)
->    400    0.002    0.000   85.264    0.213 records.py:492(get_final_molecule)
      403    0.009    0.000   84.425    0.209 adapters.py:434(send)
      403    0.009    0.000   84.215    0.209 connectionpool.py:595(urlopen)
      403    0.010    0.000   84.152    0.209 connectionpool.py:380(_make_request)
```

I also see in `test_load_from_qcsubmit` that you're calling `numpy.allclose` on `qm_conformer.coordinates` and `molecule.conformers[0]`, so I figured this was a safe thing to do. I know from my work in the past few days that `to_records` adds the `final_geometry` of an `OptimizationRecord` as the single conformer on the resulting `Molecule`, so this seemed like a good optimization. It reduced the runtime on that example from ~113 seconds above to ~21 seconds:

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   2301/1    0.038    0.000   21.247   21.247 {built-in method builtins.exec}
        1    0.000    0.000   21.247   21.247 main.py:1(<module>)
        1    0.000    0.000   19.096   19.096 core.py:1155(__call__)
        1    0.000    0.000   19.096   19.096 core.py:1010(main)
        1    0.000    0.000   19.095   19.095 core.py:1423(invoke)
        1    0.000    0.000   19.095   19.095 core.py:732(invoke)
        1    0.002    0.002   19.095   19.095 main.py:17(main)
        1    0.009    0.009   11.262   11.262 _store.py:267(from_qcsubmit_collection)
        1    0.002    0.002    7.830    7.830 _store.py:303(optimize_mm)
      233    0.006    0.000    7.787    0.033 __init__.py:1(<module>)
17867/8867    0.007    0.000    6.347    0.001 {built-in method builtins.next}
11000/3200    0.019    0.000    5.288    0.002 state_changes.py:95(_go)
     2800    0.009    0.000    5.278    0.002 _store.py:68(_get_session)
5421/1621    0.005    0.000    5.255    0.003 contextlib.py:141(__exit__)
     1400    0.001    0.000    5.231    0.004 session.py:1887(commit)
1900/1400    0.002    0.000    5.229    0.004 <string>:1(commit)
1900/1400    0.021    0.000    5.225    0.004 session.py:1232(commit)
        1    0.003    0.003    4.931    4.931 _minimize.py:28(_minimize_blob)
     1401    0.001    0.000    4.854    0.003 base.py:2598(commit)
     1401    0.005    0.000    4.853    0.003 base.py:2715(_do_commit)
```

I double-checked that no caching tricks were going on by reverting to main and running that code again, and I got a time of 1:43.13 compared to 14.769 sec with the new version.

I was also getting test failures from `foo.sqlite` hanging around after a successful run, so I added a line to that test to delete it. Finally, the tests are still going to fail because the force field in the plugin test is not tracked in the repo currently:

```
================================================= FAILURES =================================================
___________________________________________ test_plugin_loadable ___________________________________________

input = MinimizationInput(inchi_key='OTMSDBZUPAUEDD-UHFFFAOYSA-N', qcarchive_id='test', force_field='de-force-1.0.1.offxml', m...     [ 2.27674198e+00,  1.01656127e+00,  1.90807253e-01],
       [ 2.23959613e+00, -2.09655568e-01, -1.09094548e+00]]))

    def _run_openmm(
        input: MinimizationInput,
    ) -> MinimizationResult:
        inchi_key: str = input.inchi_key
        qcarchive_id: str = input.qcarchive_id
        positions: numpy.ndarray = input.coordinates
    
        molecule = Molecule.from_mapped_smiles(
            input.mapped_smiles,
            allow_undefined_stereo=True,
        )
    
        if input.force_field.startswith("gaff"):
            from ibstore._forcefields import _gaff
    
            system = _gaff(
                molecule=molecule,
                force_field_name=input.force_field,
            )
    
        else:
            try:
>               force_field = FORCE_FIELDS[input.force_field]
E               KeyError: 'de-force-1.0.1.offxml'
```