### PR TITLE
Pass chunksize to imap and avoid intermediate dict

### DIFF
--- a/ibstore/_minimize.py
+++ b/ibstore/_minimize.py
@@ -27,6 +27,7 @@ def _minimize_blob(
     input: dict[str, dict[str, Union[str, numpy.ndarray]]],
     force_field: str,
     n_processes: int = 2,
+    chunksize=32,
 ) -> dict[str, list["MinimizationResult"]]:
     returned = defaultdict(list)
     inputs = list()
@@ -59,6 +60,7 @@ def _minimize_blob(
             pool.imap(
                 _run_openmm,
                 inputs,
+                chunksize=chunksize,
             ),
             desc=f"Building and minimizing systems with {force_field}",
             total=len(inputs),

--- a/ibstore/_minimize.py
+++ b/ibstore/_minimize.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from multiprocessing import Pool
 from typing import Union
 
@@ -29,7 +28,6 @@ def _minimize_blob(
     n_processes: int = 2,
     chunksize=32,
 ) -> dict[str, list["MinimizationResult"]]:
-    returned = defaultdict(list)
     inputs = list()
 
     for inchi_key in input:
@@ -65,9 +63,7 @@ def _minimize_blob(
             desc=f"Building and minimizing systems with {force_field}",
             total=len(inputs),
         ):
-            returned[result.inchi_key].append(result)
-
-    return returned
+            yield result
 
 
 class MinimizationInput(ImmutableModel):

--- a/ibstore/_store.py
+++ b/ibstore/_store.py
@@ -347,20 +347,19 @@ class MoleculeStore:
             n_processes,
         )
 
-        for inchi_key in _minimized_blob:
+        for result in _minimized_blob:
+            inchi_key = result.inchi_key
             molecule_id = self.get_molecule_id_by_inchi_key(inchi_key)
-
-            for result in _minimized_blob[inchi_key]:
-                self.store_conformer(
-                    MMConformerRecord(
-                        molecule_id=molecule_id,
-                        qcarchive_id=result.qcarchive_id,
-                        force_field=result.force_field,
-                        mapped_smiles=result.mapped_smiles,
-                        energy=result.energy,
-                        coordinates=result.coordinates,
-                    ),
-                )
+            self.store_conformer(
+                MMConformerRecord(
+                    molecule_id=molecule_id,
+                    qcarchive_id=result.qcarchive_id,
+                    force_field=result.force_field,
+                    mapped_smiles=result.mapped_smiles,
+                    energy=result.energy,
+                    coordinates=result.coordinates,
+                ),
+            )
 
     def get_dde(
         self,

--- a/ibstore/_store.py
+++ b/ibstore/_store.py
@@ -304,6 +304,7 @@ class MoleculeStore:
         self,
         force_field: str,
         n_processes: int = 2,
+        chunksize=32,
     ):
         from ibstore._minimize import _minimize_blob
 


### PR DESCRIPTION
I was browsing the [multiprocessing docs](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.imap) for another project and noticed the suggestion:

> For very long iterables using a large value for chunksize can make the job complete **much** faster than using the default value of 1.

So I decided to try it here (first commit), and it took the runtime from about an hour on my test dataset down to 20 minutes. I'm not sure a chunksize of 32 is optimal or anything, but the other two sizes I tried were 8 and 256 and they were all comparable, right around 20 minutes. The docs for regular `map` say it's an approximate size, so maybe specifying anything just lets it leave the default. I actually made the change yesterday, but I rebased to your nprocesses commit, which I think goes nicely with this one.

The second change is trying to address my (and Lexie's) jobs on HPC3 getting OOM killed with 32 GB of RAM requested. They both died in the middle of the minimization stage, so I took a guess at something that might help. I think we've now both finished those runs successfully with 64 GB, but I figured it was still worth trying to reduce memory usage in case we need to expand to even larger datasets. I tried getting some real memory profiles, but it was a lot harder than the CPU profiles I'm more used to, especially with the multiprocessing. I also noticed a slight speedup from 20 minutes to about 19:30 after this change, which might be a good sign of having to allocate/free less memory or might just be noise in the single measurements.

I tried returning the `pool.imap` call directly instead of calling `yield`, but in that case nothing actually ran. I may not fully understand how the `yield` stuff works (or especially how it interacts with multiprocessing, but it seems to work), so I think it would still be an improvement just to return a list of results rather than a dict of `inchi_key: List[result]` pairs like before.