### PR TITLE
Allow using espaloma as a force field

### DIFF
--- a/devtools/conda-envs/dev.yaml
+++ b/devtools/conda-envs/dev.yaml
@@ -9,6 +9,7 @@ dependencies:
   - openff-qcsubmit
   - openmmforcefields
   - smirnoff-plugins =2023.08.0
+  - espaloma
 
   - ipython
   - ipdb

--- a/ibstore/_minimize.py
+++ b/ibstore/_minimize.py
@@ -114,6 +114,27 @@ def _run_openmm(
             force_field_name=input.force_field,
         )
 
+    elif input.force_field.startswith("espaloma"):
+        import espaloma as esp
+
+        # espaloma needs an OpenFF force field too, so provide it as
+        # espaloma-openff-2.1.0, for example. use a slice in case it's empty
+        ff = input.force_field.split("-", 1)[1:2]
+
+        if ff == []:
+            raise ValueError(
+                "espaloma force field must have an OpenFF force field too"
+            )
+        else:
+            ff = ff[0]
+
+        mol_graph = esp.Graph(molecule)
+        model = esp.get_model("latest")
+        model(mol_graph.heterograph)
+        system = esp.graphs.deploy.openmm_system_from_graph(
+            mol_graph, forcefield=ff
+        )
+
     else:
         try:
             force_field = FORCE_FIELDS[input.force_field]

--- a/ibstore/_minimize.py
+++ b/ibstore/_minimize.py
@@ -115,24 +115,11 @@ def _run_openmm(
         )
 
     elif input.force_field.startswith("espaloma"):
-        import espaloma as esp
+        from ibstore._forcefields import _espaloma
 
-        # espaloma needs an OpenFF force field too, so provide it as
-        # espaloma-openff-2.1.0, for example. use a slice in case it's empty
-        ff = input.force_field.split("-", 1)[1:2]
-
-        if ff == []:
-            raise ValueError(
-                "espaloma force field must have an OpenFF force field too"
-            )
-        else:
-            ff = ff[0]
-
-        mol_graph = esp.Graph(molecule)
-        model = esp.get_model("latest")
-        model(mol_graph.heterograph)
-        system = esp.graphs.deploy.openmm_system_from_graph(
-            mol_graph, forcefield=ff
+        system = _espaloma(
+            molecule=molecule,
+            force_field_name=input.force_field,
         )
 
     else:

--- a/ibstore/_tests/unit_tests/test_forcefields.py
+++ b/ibstore/_tests/unit_tests/test_forcefields.py
@@ -2,7 +2,7 @@ import openmm
 import pytest
 from openff.toolkit import Molecule
 
-from ibstore._forcefields import _gaff, _smirnoff
+from ibstore._forcefields import _espaloma, _gaff, _smirnoff
 
 
 @pytest.fixture()
@@ -27,3 +27,15 @@ def test_gaff_basic(molecule):
 def test_gaff_unsupported(molecule):
     with pytest.raises(NotImplementedError):
         _gaff(molecule, "foo")
+
+
+def test_espaloma_basic(molecule):
+    system = _espaloma(molecule, "espaloma-openff_unconstrained-2.1.0")
+
+    assert isinstance(system, openmm.System)
+    assert system.getNumParticles() == molecule.n_atoms
+
+
+def test_espaloma_unsupported(molecule):
+    with pytest.raises(NotImplementedError):
+        _espaloma(molecule, "foo")


### PR DESCRIPTION
I've been playing with some hybrid espaloma/smirnoff force fields recently, and Lily said it would be a good idea to benchmark espaloma for comparison. I thought this would be a lot more work, but it only took a few lines.

I think the biggest question is what to do if there is no OpenFF force field provided along with espaloma. Espaloma itself defaults to `openff_unconstrained-2.0.0`, so we could use that or another default. I successfully ran a benchmark locally on a small data set with `espaloma-openff_unconstrained-2.1.0` as my force field argument, so that could be a good default. For now I just made it raise a `ValueError` if there's nothing after the dash. At some point it may also be necessary to pass a different espaloma model than `latest`, but that's all I've used so far.

This probably doesn't belong in this repo, but I used the installation instructions straight from the [espaloma repo](https://github.com/choderalab/espaloma#installation) to get espaloma: `conda install -c conda-forge "espaloma=0.3.2"`