### PR TITLE
Add `ICRMSD.to_csv`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,9 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest -v -nauto --cov=ibstore/ --cov-report=xml ibstore/
+        pytest -v -nauto --durations=10 \
+          --cov=ibstore/ --cov-report=xml \
+          ibstore/
 
     - name: CodeCov
       uses: codecov/codecov-action@v3

--- a/ibstore/_minimize.py
+++ b/ibstore/_minimize.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 from ibstore._base.array import Array
 from ibstore._base.base import ImmutableModel
 
+# TODO: This causes all of these to be loaded at import time, which is not ideal
 FORCE_FIELDS: dict[str, ForceField] = {
     "openff-1.0.0": ForceField("openff_unconstrained-1.0.0.offxml"),
     "openff-1.1.0": ForceField("openff_unconstrained-1.1.0.offxml"),
@@ -19,6 +20,10 @@ FORCE_FIELDS: dict[str, ForceField] = {
     "openff-1.3.0": ForceField("openff_unconstrained-1.3.0.offxml"),
     "openff-2.0.0": ForceField("openff_unconstrained-2.0.0.offxml"),
     "openff-2.1.0": ForceField("openff_unconstrained-2.1.0.offxml"),
+    "de-force-1.0.1": ForceField(
+        "de-force_unconstrained-1.0.1.offxml",
+        load_plugins=True,
+    ),
 }
 
 

--- a/ibstore/_tests/unit_tests/test_analysis.py
+++ b/ibstore/_tests/unit_tests/test_analysis.py
@@ -55,7 +55,7 @@ class TestInternalCoordinateRMSD:
 
     def test_icrmsd_dataframe(self, small_store):
         dataframe = small_store.get_internal_coordinate_rmsd(
-            "openff-2.0.0.offxml",
+            "openff-2.0.0",
         ).to_dataframe()
 
         cumene_id = small_store.get_molecule_id_by_qcarchive_id(37017037)
@@ -75,7 +75,7 @@ class TestInternalCoordinateRMSD:
 
     def test_torsions_not_in_methane_icrmsd(self, small_store):
         dataframe = small_store.get_internal_coordinate_rmsd(
-            "openff-2.0.0.offxml",
+            "openff-2.0.0",
         ).to_dataframe()
 
         methane_id = small_store.get_molecule_id_by_qcarchive_id(37017014)

--- a/ibstore/_tests/unit_tests/test_analysis.py
+++ b/ibstore/_tests/unit_tests/test_analysis.py
@@ -1,11 +1,7 @@
-"""
-def get_internal_coordinate_rmsds(
-    molecule: Molecule,
-    reference: Array,
-    target: Array,
-    _types: tuple[str] = ("Bond", "Angle", "Dihedral", "Improper"),
-) -> dict[str, float]:
-"""
+import pandas
+import pytest
+from openff.toolkit import Molecule
+
 from ibstore.analysis import get_internal_coordinate_rmsds
 
 
@@ -56,3 +52,44 @@ class TestInternalCoordinateRMSD:
 
         assert "Dihedral" in rmsds
         assert "Improper" not in rmsds
+
+    def test_icrmsd_dataframe(self, small_store):
+        dataframe = small_store.get_internal_coordinate_rmsd(
+            "openff-2.0.0.offxml",
+        ).to_dataframe()
+
+        cumene_id = small_store.get_molecule_id_by_qcarchive_id(37017037)
+
+        # This molecule should be cumene
+        assert Molecule.from_mapped_smiles(
+            small_store.get_smiles_by_molecule_id(cumene_id),
+        ).is_isomorphic_with(Molecule.from_smiles("CC(C)c1ccccc1"))
+
+        for qcarchive_id in small_store.get_qcarchive_ids_by_molecule_id(cumene_id):
+            # This should probably be an int, but it's str
+            data = dataframe.loc[int(qcarchive_id)]
+
+            for key in ("Bond", "Angle", "Dihedral", "Improper"):
+                assert isinstance(data[key], float)
+                assert data[key] != pytest.approx(0.0)
+
+    def test_torsions_not_in_methane_icrmsd(self, small_store):
+        dataframe = small_store.get_internal_coordinate_rmsd(
+            "openff-2.0.0.offxml",
+        ).to_dataframe()
+
+        methane_id = small_store.get_molecule_id_by_qcarchive_id(37017014)
+
+        # This molecule should be methane
+        assert Molecule.from_mapped_smiles(
+            small_store.get_smiles_by_molecule_id(methane_id),
+        ).is_isomorphic_with(Molecule.from_smiles("C"))
+
+        for qcarchive_id in small_store.get_qcarchive_ids_by_molecule_id(methane_id):
+            # This should probably be an int, but it's str
+            data = dataframe.loc[int(qcarchive_id)]
+
+            assert isinstance(data["Bond"], float)
+            assert isinstance(data["Angle"], float)
+            assert data["Dihedral"] is pandas.NA
+            assert data["Improper"] is pandas.NA

--- a/ibstore/_tests/unit_tests/test_minimize.py
+++ b/ibstore/_tests/unit_tests/test_minimize.py
@@ -85,7 +85,7 @@ def test_plugin_loadable(ethane):
         MinimizationInput(
             inchi_key=ethane.to_inchikey(),
             qcarchive_id="test",
-            force_field="de-force-1.0.1.offxml",
+            force_field="de-force-1.0.1",
             mapped_smiles=ethane.to_smiles(mapped=True),
             coordinates=ethane.conformers[0].m_as(unit.angstrom),
         ),

--- a/ibstore/_tests/unit_tests/test_store.py
+++ b/ibstore/_tests/unit_tests/test_store.py
@@ -13,23 +13,6 @@ from ibstore.exceptions import DatabaseExistsError
 from ibstore.models import MMConformerRecord, QMConformerRecord
 
 
-@pytest.fixture()
-def basic_ch_store():
-    # This file manually generated from data/01-processed-qm-ch.json
-    return MoleculeStore(
-        get_data_file_path(
-            "_tests/data/ch.sqlite",
-            package_name="ibstore",
-        ),
-    )
-
-
-@pytest.fixture()
-def diphenylvinylbenzene():
-    """Return 1,2-diphenylvinylbenzene"""
-    return Molecule.from_smiles("c1ccc(cc1)C=C(c2ccccc2)c3ccccc3")
-
-
 def test_from_qcsubmit(small_collection):
     db = "foo.sqlite"
     with temporary_cd():
@@ -51,8 +34,8 @@ def test_do_not_overwrite(small_collection):
             )
 
 
-def test_load_existing_database(basic_ch_store):
-    assert len(basic_ch_store) == 40
+def test_load_existing_database(small_store):
+    assert len(small_store) == 40
 
 
 def test_get_molecule_ids(small_store):
@@ -117,8 +100,8 @@ def test_get_conformers(small_store):
     )
 
 
-def test_get_force_fields(basic_ch_store):
-    force_fields = basic_ch_store.get_force_fields()
+def test_get_force_fields(small_store):
+    force_fields = small_store.get_force_fields()
 
     assert len(force_fields) == 9
 
@@ -127,8 +110,8 @@ def test_get_force_fields(basic_ch_store):
     assert "openff-3.0.0" not in force_fields
 
 
-def test_get_mm_conformer_records_by_molecule_id(basic_ch_store, diphenylvinylbenzene):
-    records = basic_ch_store.get_mm_conformer_records_by_molecule_id(
+def test_get_mm_conformer_records_by_molecule_id(small_store, diphenylvinylbenzene):
+    records = small_store.get_mm_conformer_records_by_molecule_id(
         1,
         force_field="openff-2.1.0",
     )
@@ -145,8 +128,8 @@ def test_get_mm_conformer_records_by_molecule_id(basic_ch_store, diphenylvinylbe
         )
 
 
-def test_get_qm_conformer_records_by_molecule_id(basic_ch_store, diphenylvinylbenzene):
-    records = basic_ch_store.get_qm_conformer_records_by_molecule_id(1)
+def test_get_qm_conformer_records_by_molecule_id(small_store, diphenylvinylbenzene):
+    records = small_store.get_qm_conformer_records_by_molecule_id(1)
 
     for record in records:
         assert isinstance(record, QMConformerRecord)

--- a/ibstore/analysis.py
+++ b/ibstore/analysis.py
@@ -50,7 +50,23 @@ class ICRMSD(ImmutableModel):
 
 
 class ICRMSDCollection(list):
-    pass
+    def to_dataframe(self) -> pandas.DataFrame:
+        return pandas.DataFrame(
+            [
+                (
+                    icrmsd.icrmsd["Bond"],
+                    icrmsd.icrmsd["Angle"],
+                    icrmsd.icrmsd.get("Dihedral", pandas.NA),
+                    icrmsd.icrmsd.get("Improper", pandas.NA),
+                )
+                for icrmsd in self
+            ],
+            index=pandas.Index([rmsd.qcarchive_id for rmsd in self]),
+            columns=["Bond", "Angle", "Dihedral", "Improper"],
+        )
+
+    def to_csv(self, path: str):
+        self.to_dataframe().to_csv(path)
 
 
 class TFD(ImmutableModel):


### PR DESCRIPTION
The only quirk I intentionally introduced is that the dataframe has NaNs for internal coordinate RMSD  types that are not present in the molecule, i.e. a molecule without impropers will be some sort of NaN in memory and an empty column (for that row) in the CSV file

```python
In [1]: from ibstore import MoleculeStore

In [2]: store = MoleculeStore("ibstore/_tests/data/ch.sqlite")

In [3]: store.get_internal_coordinate_rmsd("openff-2.1.0.offxml").to_csv("tmp.cs
   ...: v")

In [4]: !head tmp.csv
,Bond,Angle,Dihedral,Improper
37016993,0.006765353215413105,0.5562185080355656,1.6377223353487484,8.741271028611663e-05
37016854,0.007502142167449161,0.6192872461761049,1.038979039777575,
37016855,0.006833667914207529,0.8319266771498063,1.4919597214037241,
37016856,0.006833011342923914,0.8318419685070038,1.4898176624291597,
37016857,0.0058978815367170135,0.7836030843583247,1.538729375185381,
37016858,0.005898499199221772,0.7837631466083518,1.5462489136810058,
37016859,0.006037055028578897,1.010201068668402,1.161957731826734,
37017102,0.014862708012371406,1.0988051313006353,5.569310966093644e-12,3.4567739785894855e-12
37016810,0.006073102260928175,0.7018525923781802,2.3447115578558857,0.1276783057425198