### PR TITLE
Cache loading of force fields

### DIFF
--- a/devtools/conda-envs/dev.yaml
+++ b/devtools/conda-envs/dev.yaml
@@ -23,6 +23,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - pytest-randomly
+  - pytest-timeout
 
   - pip:
     - git+https://github.com/mattwthompson/de-forcefields.git@periodic-nonperiodic-methods


### PR DESCRIPTION
Resolves #19

I got a little carried away, this changeset includes
* Force field loading is now cached
* Force fields are no longer loaded at module import time
* Non-mainline force fields are not required at runtime if not used
* Constrained force fields can be used (though are not fully wired up)