### PR TITLE
Use index of QM minimum energy as MM reference point

### DIFF
--- a/ibstore/_store.py
+++ b/ibstore/_store.py
@@ -486,14 +486,29 @@ class MoleculeStore:
                 # TODO: Quicker way of short-circuiting here
                 continue
 
-            qm_energies = self.get_qm_energies_by_molecule_id(molecule_id)
-            qm_energies -= numpy.array(qm_energies).min()
+            qm_energies = numpy.array(
+                self.get_qm_energies_by_molecule_id(
+                    molecule_id,
+                ),
+            )
 
-            mm_energies = self.get_mm_energies_by_molecule_id(molecule_id, force_field)
+            mm_energies = numpy.array(
+                self.get_mm_energies_by_molecule_id(
+                    molecule_id,
+                    force_field,
+                ),
+            )
+
             if len(mm_energies) != len(qm_energies):
                 continue
 
-            mm_energies -= numpy.array(mm_energies).min()
+            qm_minimum_index = qm_energies.argmin()
+
+            mm_energies -= mm_energies[qm_minimum_index]
+            qm_energies -= qm_energies[qm_minimum_index]
+
+            mm_energies[qm_minimum_index] = numpy.nan
+            qm_energies[qm_minimum_index] = numpy.nan
 
             for qm, mm, id in zip(
                 qm_energies,

--- a/run.py
+++ b/run.py
@@ -22,7 +22,7 @@ def main():
         "de-force-1.0.1.offxml",
     ]
 
-    data = "cho"
+    data = "ch"
 
     if pathlib.Path(f"{data}.sqlite").exists():
         store = MoleculeStore(f"{data}.sqlite")
@@ -46,7 +46,7 @@ def main():
     plot(force_fields)
 
 
-def plot(force_fields):
+def plot(force_fields: list[str]):
     x_ranges = {
         "dde": (-16.0, 16.0),
         "rmsd": (-0.3, 3.3),
@@ -60,7 +60,7 @@ def plot(force_fields):
             if data == "dde":
                 counts, bins = numpy.histogram(
                     dataframe[dataframe.columns[-1]],
-                    bins=numpy.linspace(-15, 15, 16),
+                    bins=numpy.linspace(-15, 15, 31),
                 )
 
                 axis.stairs(counts, bins, label=force_field)


### PR DESCRIPTION
Resolves #23 

This PR changes the MM $dE$ calculation to use the conform having a minimum QM energy as the reference conformer. Previously the conformer having a minimum MM energy was used. (This is still the behavior of the QM $dE$ calculation). This is more commonly used, or at least more commonly preferred. IIUC this has negligible qualitative impact but some quantitative impact, which is useful for comparing to existing result.

Just using the toy CH dataset, results with this branch

![image](https://github.com/mattwthompson/ib/assets/7935382/6bcdd9b8-945d-4d7f-9db3-bb94180929d7)

compare okay to [0.0.4](https://github.com/mattwthompson/ib/releases/tag/0.0.4), I think?

![image](https://github.com/mattwthompson/ib/assets/7935382/9fb37c50-0a25-4842-aeee-1980f094bbf6)
