### PR TITLE
Use only Pydantic v2 in installation

### DIFF
--- a/devtools/conda-envs/dev.yaml
+++ b/devtools/conda-envs/dev.yaml
@@ -3,14 +3,15 @@ channels:
   - openeye
   - conda-forge
 dependencies:
-  - python
+  - python =3.10
 
-  - openff-toolkit =0.14.3
-  - openff-qcsubmit =0.50.1
+  - openff-toolkit
+  - openff-qcsubmit
   - openmmforcefields
-  - smirnoff-plugins =2023.08.0
+  - smirnoff-plugins
   # espaloma =0.3
   - geometric =1
+  - pydantic =2
 
   - ipython
   - ipdb

--- a/ibstore/_base/base.py
+++ b/ibstore/_base/base.py
@@ -7,8 +7,8 @@ from typing import Any, ClassVar, Dict, List, Optional, Type, Union, no_type_che
 
 import numpy
 from openff.units import unit
-from pydantic import BaseModel
-from pydantic.errors import DictError
+from pydantic.v1 import BaseModel
+from pydantic.v1.errors import DictError
 
 FloatArrayLike = Union[List, numpy.ndarray, float]
 

--- a/ibstore/_minimize.py
+++ b/ibstore/_minimize.py
@@ -9,7 +9,7 @@ import openmm.app
 import openmm.unit
 from openff.toolkit import ForceField, Molecule
 from openff.toolkit.typing.engines.smirnoff import get_available_force_fields
-from pydantic import Field
+from pydantic.v1 import Field
 from tqdm import tqdm
 
 from ibstore._base.array import Array

--- a/ibstore/models.py
+++ b/ibstore/models.py
@@ -2,7 +2,7 @@ from typing import Any, TypeVar
 
 import qcelemental
 from openff.toolkit import Molecule
-from pydantic import Field
+from pydantic.v1 import Field
 
 from ibstore._base.array import Array
 from ibstore._base.base import ImmutableModel


### PR DESCRIPTION
Something got funky in my local environment and I think it's time to just avoid differences in installed versions